### PR TITLE
Options template for sandboxed applications

### DIFF
--- a/configuration/common-sandboxed-app.properties
+++ b/configuration/common-sandboxed-app.properties
@@ -2,11 +2,6 @@
 # Runtime Options
 ###############################################################################
 
-## Types
-
-# Embeds the name of all types. When this option is disabled, only names of declared required types are embedded.
-#soar.generate.classnames=true
-
 ## Assertions
 
 # When this option is enabled, asserts statements are executed on Simulator.


### PR DESCRIPTION
A customer requested me to provide a template for options applicable to sandboxed app projects.

In this MR, I propose to provide a different file as part of the template (when using the template, user should select the relevant file and remove others).
This MR only provides a new file for sandboxed app projects.

Maybe we should also split single app vs kernel? Although, it should just be adding/removing the multiapp section, similarly to other foundation libraries (NET/FS/BLUETOOTH/...).

Unfortunately, we do not have user documentation on how to use this template so I cannot update it with this information..