### PR TITLE
Fix default value for soar.generate.classnames

### DIFF
--- a/configuration/common.properties
+++ b/configuration/common.properties
@@ -5,7 +5,7 @@
 ## Types
 
 # Embeds the name of all types. When this option is disabled, only names of declared required types are embedded.
-#soar.generate.classnames=true
+#soar.generate.classnames=false
 
 ## Assertions
 


### PR DESCRIPTION
https://docs.microej.com/en/latest/ApplicationDeveloperGuide/standaloneApplication.html#option-checkbox-embed-all-type-names