### PR TITLE
Add commented SPDX SBOM generation setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,9 @@
 plugins {
     id("com.microej.gradle.application") version "1.7.0"
+
+    // Uncomment this plugin and the spdxSbom block at the end of this file to generate an SBOM in SPDX format
+    // See https://docs.microej.com/en/latest/SDK6UserGuide/generateSbom.html
+    //id("org.spdx.sbom") version "0.12.0"
 }
 
 group="com.mycompany"
@@ -34,3 +38,24 @@ testing {
       }
    }
 }
+
+//Uncomment this block and the org.spdx.sbom plugin above to generate an SBOM in SPDX format,
+//then run "./gradlew spdxSbom". The SBOM files are written under "build/spdx/".
+//See https://docs.microej.com/en/latest/SDK6UserGuide/generateSbom.html
+//spdxSbom {
+//    targets {
+//        create("release") {
+//            configurations.set(listOf("microejSbomClasspath"))
+//
+//            document {
+//                name.set("My Product SBOM")
+//                namespace.set("https://my.company.org/spdx/")
+//                creator.set("Organization: My Company")
+//                packageSupplier.set("Organization: My Company")
+//            }
+//
+//            // Uncomment the line below to ignore SDK 5 modules
+//            //ignoreNonMavenDependencies.set(true)
+//        }
+//    }
+//}


### PR DESCRIPTION
If the spdx block is uncommented the build will fail with `No POM file found for dependency ej.api:edc:1.3.7` because the  central repository hasn't yet been rebuilt with the SDK 6  metadata the doc lists as a prerequisite (= without Maven metadata generated for SDK 5 modules like edc).
It may be best to wait for the central repo to be migrated before merging this branch